### PR TITLE
Action._transaction does not read the entire bert response

### DIFF
--- a/bertrpc/client.py
+++ b/bertrpc/client.py
@@ -97,8 +97,14 @@ class Action(object):
             lenheader = sock.recv(4)
             if lenheader is None: raise error.ProtocolError(error.ProtocolError.NO_HEADER)
             length = struct.unpack(">l",lenheader)[0]
-            bert_response = sock.recv(length)
-            if bert_response is None or len(bert_response) == 0: raise error.ProtocolError(error.ProtocolError.NO_DATA)
+
+            bert_response = ''
+            while len(bert_response) < length:
+                response_part = sock.recv(length - len(bert_response))
+                if response_part is None or len(response_part) == 0:
+                    raise error.ProtocolError(error.ProtocolError.NO_DATA)
+                bert_response += response_part
+
             sock.close()
             return bert_response
         except socket.timeout, e:


### PR DESCRIPTION
I ran into an issue where the BERT decoder was failing because of truncated data. The actual error message varies depending on which function the decoder is in when it reaches the end of the data. It turns out that socket.recv was only being called once, even if the length of the data it returned was less than the length of the data indicated by the BERP header.

Here is a gist I've created to demonstrate the problem: https://gist.github.com/1010888 . It includes a python-ernie service that returns an arbitrary amount of data and a python-bertrpc client that reads from this service. It also includes an example terminal session showing both the usage and the error.
